### PR TITLE
Update headings.f: parameter nentries=19

### DIFF
--- a/src/headings.f
+++ b/src/headings.f
@@ -31,6 +31,8 @@
       integer istat,n,key,iline,ipol,inl,ipoinp(2,*),inp(3,*),
      &  ipoinpc(0:*),i,j,nentries,nheading,istep,irstrt(*),ier
 !
+      parameter(nentries=19)
+      
       if((istep.gt.0).and.(irstrt(1).ge.0)) then
          write(*,*) '*ERROR reading *HEADING: *HEADING should be placed'
          write(*,*) '       before all step definitions'


### PR DESCRIPTION
added line "parameter(nentries=19)" because variable nentries is being declared and used, but not initialized in subroutine headings(). With this change variable nentries is being set as a parameter as in all other files where this variable is being used.